### PR TITLE
remove deprecated derive(Show)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub struct IdsContainer<T> {
     next_id: u32
 }
 
-#[derive(Copy, Clone, Show, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Id {
     value: u32,
 }


### PR DESCRIPTION
`derive(Show)` has been deprecated for a while. This is the only regression detected by crater. See also [the pull request that will break this crate](https://github.com/rust-lang/rust/pull/29148#issuecomment-149268767)
